### PR TITLE
[#209] SwagEdit shows "Unable to Dereference URI" error on Swagger Schema

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/schema.json
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
-  "id": "http://swagger.io/v2/schema.json#",
+  "id": "#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [


### PR DESCRIPTION
Make the schema anonymous to avoid connection exception if swagger server is down.